### PR TITLE
SBP-9 Catalog service get paged inconsistency

### DIFF
--- a/Services/book_catalog_service/Cargo.lock
+++ b/Services/book_catalog_service/Cargo.lock
@@ -15,15 +15,6 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
@@ -51,6 +42,15 @@ name = "anymap"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+
+[[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
 
 [[package]]
 name = "async-stream"
@@ -168,7 +168,7 @@ dependencies = [
  "dotenv",
  "envy",
  "futures",
- "isbnid",
+ "isbn",
  "mediator",
  "mockall",
  "mongodb",
@@ -241,6 +241,15 @@ dependencies = [
  "time 0.1.44",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "codegen"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34c59e8a9b988977ec3bd61ab380cf1167048817ecd3d6999fac03657f85a609"
+dependencies = [
+ "indexmap",
 ]
 
 [[package]]
@@ -779,12 +788,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
-name = "isbnid"
-version = "0.1.3"
+name = "isbn"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185711027e614eb9df8b9974efbe46bb4b7eef326825167baba1c288473b23c6"
+checksum = "129e187613e6c51e562ce485d2981705a125a65b3d61e48d2c320ea6b6d60d5b"
 dependencies = [
- "regex 0.2.11",
+ "arrayvec",
+ "codegen",
+ "roxmltree",
 ]
 
 [[package]]
@@ -998,6 +1009,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,7 +1171,7 @@ dependencies = [
  "itertools",
  "normalize-line-endings",
  "predicates-core",
- "regex 1.6.0",
+ "regex",
 ]
 
 [[package]]
@@ -1217,7 +1234,7 @@ dependencies = [
  "petgraph",
  "prost",
  "prost-types",
- "regex 1.6.0",
+ "regex",
  "tempfile",
  "which",
 ]
@@ -1301,35 +1318,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-dependencies = [
- "aho-corasick 0.6.10",
- "memchr",
- "regex-syntax 0.5.6",
- "thread_local",
- "utf8-ranges",
-]
-
-[[package]]
-name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
- "aho-corasick 0.7.19",
+ "aho-corasick",
  "memchr",
- "regex-syntax 0.6.27",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-dependencies = [
- "ucd-util",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1370,6 +1365,15 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02660467d0c2da1b6276042501aee6e15ec5b8ff59423243f185b294cd53acf3"
+dependencies = [
+ "xmlparser",
 ]
 
 [[package]]
@@ -1731,15 +1735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,12 +2062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
-name = "ucd-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bfcbf611b122f2c10eb1bb6172fbc4c2e25df9970330e4d75ce2b5201c9bfc"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,12 +2098,6 @@ dependencies = [
  "idna 0.3.0",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "uuid"
@@ -2356,3 +2339,9 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78a7f29bb57edf63321d545d84f99360df71df36929a090bc067e1bcb65e34d"

--- a/Services/book_catalog_service/Cargo.toml
+++ b/Services/book_catalog_service/Cargo.toml
@@ -14,7 +14,7 @@ domain_patterns = "0.2.141"
 dotenv = "0.15.0"
 envy = "0.4.2"
 futures = "0.3.24"
-isbnid = "0.1.3"
+isbn = "0.2.0"
 mediator = { version = "0.2.2", features = ["async", "async-trait"] }
 mockall = "0.11.2"
 mongodb = "2.3.0"

--- a/Services/book_catalog_service/src/application/query/get_paged_books.rs
+++ b/Services/book_catalog_service/src/application/query/get_paged_books.rs
@@ -28,7 +28,7 @@ impl AsyncRequestHandler<GetPagedBooksQuery, Result<Option<Vec<BookDto>>, Server
     async fn handle(&mut self, req: GetPagedBooksQuery) -> Result<Option<Vec<BookDto>>, ServerErrorType> {
         // if there is any major error, pass it to the grpc server
         let books = self.repository
-            .get_paged(req.page, req.page_size)
+            .get_all()
             .await?;
 
         // if there is no error, but no books are found, return None
@@ -36,11 +36,13 @@ impl AsyncRequestHandler<GetPagedBooksQuery, Result<Option<Vec<BookDto>>, Server
             return Ok(None);
         }
 
-        // return only valid books
+        // return only valid books with respect to the pagination parameters
         Ok(Some(books
             .unwrap()
             .into_iter()
             .filter_map(Result::ok)
+            .skip((req.page * req.page_size) as usize)
+            .take(req.page_size as usize)
             .map(|book| book.into())
             .collect()
         ))
@@ -49,11 +51,13 @@ impl AsyncRequestHandler<GetPagedBooksQuery, Result<Option<Vec<BookDto>>, Server
 
 #[cfg(test)]
 mod get_paged_books_unit_tests {
+    use std::iter::zip;
+    use std::str::FromStr;
     use super::*;
     use std::sync::Arc;
     use mockall::mock;
     use async_trait::async_trait;
-    use isbnid::isbn::ISBN;
+    use isbn::Isbn13;
     use mediator::AsyncRequestHandler;
     use crate::domain::book::book_entity::{Book, IsbnWrapper};
     use crate::domain::book::publisher::Publisher;
@@ -62,9 +66,77 @@ mod get_paged_books_unit_tests {
     use crate::infrastructure::core::errors::ServerErrorType;
     use crate::IRepository;
 
+    fn get_list_of_raw_isbns() -> Vec<String> {
+        vec![
+            "978-3-16-148410-0".to_string(),
+            "978-3-16-148410-0".to_string(),
+            "978-3-16-148410-0".to_string(),
+        ]
+    }
+
+    fn get_list_of_raw_books() -> Result<Option<Vec<Result<Book, ServerErrorType>>>, ServerErrorType> {
+        Ok(Some(
+            vec![
+                Ok(Book {
+                    id: Default::default(),
+                    isbn: IsbnWrapper(Isbn13::from_str("978-3-16-148410-0").unwrap()),
+                    title: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy 1".to_string()).unwrap(),
+                    authors: None,
+                    publisher: Publisher {
+                        name: RblStringVvo::try_from("Pan Books".to_string()).unwrap(),
+                        address: RblStringVvo::try_from("London".to_string()).unwrap(),
+                    },
+                    short_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
+                    long_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
+                    price: PositiveFloatVvo::try_from(10.0).unwrap(),
+                    genre: Genre::Unknown,
+                    year: ReleaseYearVvo::try_from(1979).unwrap(),
+                    num_pages: PositiveIntVvo::try_from(224).unwrap(),
+                    cover_image: None,
+                }),
+                Err(ServerErrorType::InvalidEntityFound { message: "Invalid book found".to_string() }),
+                Ok(Book {
+                    id: Default::default(),
+                    isbn: IsbnWrapper(Isbn13::from_str("978-3-16-148410-0").unwrap()),
+                    title: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy 2".to_string()).unwrap(),
+                    authors: None,
+                    publisher: Publisher {
+                        name: RblStringVvo::try_from("Pan Books".to_string()).unwrap(),
+                        address: RblStringVvo::try_from("London".to_string()).unwrap(),
+                    },
+                    short_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
+                    long_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
+                    price: PositiveFloatVvo::try_from(10.0).unwrap(),
+                    genre: Genre::Unknown,
+                    year: ReleaseYearVvo::try_from(1979).unwrap(),
+                    num_pages: PositiveIntVvo::try_from(224).unwrap(),
+                    cover_image: None,
+                }),
+                Err(ServerErrorType::InvalidEntityFound { message: "Invalid book found".to_string() }),
+                Ok(Book {
+                    id: Default::default(),
+                    isbn: IsbnWrapper(Isbn13::from_str("978-3-16-148410-0").unwrap()),
+                    title: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy 3".to_string()).unwrap(),
+                    authors: None,
+                    publisher: Publisher {
+                        name: RblStringVvo::try_from("Pan Books".to_string()).unwrap(),
+                        address: RblStringVvo::try_from("London".to_string()).unwrap(),
+                    },
+                    short_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
+                    long_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
+                    price: PositiveFloatVvo::try_from(10.0).unwrap(),
+                    genre: Genre::Unknown,
+                    year: ReleaseYearVvo::try_from(1979).unwrap(),
+                    num_pages: PositiveIntVvo::try_from(224).unwrap(),
+                    cover_image: None,
+                }),
+            ]
+        ))
+    }
+
     mock! {
         pub BookRepository {
-            fn get_paged(&self, page: u32, page_size: u32) -> Result<Option<Vec<Result<Book, ServerErrorType>>>, ServerErrorType>;
+            fn get_all(&self) -> Result<Option<Vec<Result<Book, ServerErrorType>>>, ServerErrorType>;
         }
     }
 
@@ -72,8 +144,8 @@ mod get_paged_books_unit_tests {
     impl IRepository<Book> for MockBookRepository {
         type Error = ServerErrorType;
 
-        async fn get_paged(&self, page: u32, page_size: u32) -> Result<Option<Vec<Result<Book, Self::Error>>>, Self::Error> {
-            self.get_paged(page, page_size)
+        async fn get_all(&self) -> Result<Option<Vec<Result<Book, Self::Error>>>, Self::Error> {
+            self.get_all()
         }
     }
 
@@ -81,71 +153,38 @@ mod get_paged_books_unit_tests {
     async fn when_invoking_a_get_paged_books_request_upon_a_list_of_books_then_a_list_of_valid_books_only_is_returned() {
         let mut repository = MockBookRepository::new();
         repository
-            .expect_get_paged()
+            .expect_get_all()
             .times(1)
-            .returning(|_, _| {
-                Ok(Some(
-                    vec![
-                        Ok(Book {
-                            id: Default::default(),
-                            isbn: IsbnWrapper(ISBN::new("978-3-16-148410-0").unwrap()),
-                            title: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy".to_string()).unwrap(),
-                            authors: None,
-                            publisher: Publisher {
-                                name: RblStringVvo::try_from("Pan Books".to_string()).unwrap(),
-                                address: RblStringVvo::try_from("London".to_string()).unwrap(),
-                            },
-                            short_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
-                            long_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
-                            price: PositiveFloatVvo::try_from(10.0).unwrap(),
-                            genre: Genre::Unknown,
-                            year: ReleaseYearVvo::try_from(1979).unwrap(),
-                            num_pages: PositiveIntVvo::try_from(224).unwrap(),
-                            cover_image: None,
-                        }),
-                        Err(ServerErrorType::InvalidEntityFound { message: "Invalid book found".to_string() }),
-                        Ok(Book {
-                            id: Default::default(),
-                            isbn: IsbnWrapper(ISBN::new("978-3-16-148410-0").unwrap()),
-                            title: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy".to_string()).unwrap(),
-                            authors: None,
-                            publisher: Publisher {
-                                name: RblStringVvo::try_from("Pan Books".to_string()).unwrap(),
-                                address: RblStringVvo::try_from("London".to_string()).unwrap(),
-                            },
-                            short_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
-                            long_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
-                            price: PositiveFloatVvo::try_from(10.0).unwrap(),
-                            genre: Genre::Unknown,
-                            year: ReleaseYearVvo::try_from(1979).unwrap(),
-                            num_pages: PositiveIntVvo::try_from(224).unwrap(),
-                            cover_image: None,
-                        }),
-                        Err(ServerErrorType::InvalidEntityFound { message: "Invalid book found".to_string() }),
-                        Ok(Book {
-                            id: Default::default(),
-                            isbn: IsbnWrapper(ISBN::new("978-3-16-148410-0").unwrap()),
-                            title: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy".to_string()).unwrap(),
-                            authors: None,
-                            publisher: Publisher {
-                                name: RblStringVvo::try_from("Pan Books".to_string()).unwrap(),
-                                address: RblStringVvo::try_from("London".to_string()).unwrap(),
-                            },
-                            short_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
-                            long_description: RblStringVvo::try_from("The Hitchhiker's Guide to the Galaxy is a comedy science fiction series created by Douglas Adams.".to_string()).unwrap(),
-                            price: PositiveFloatVvo::try_from(10.0).unwrap(),
-                            genre: Genre::Unknown,
-                            year: ReleaseYearVvo::try_from(1979).unwrap(),
-                            num_pages: PositiveIntVvo::try_from(224).unwrap(),
-                            cover_image: None,
-                        }),
-                    ]
-                ))
+            .returning(|| {
+                get_list_of_raw_books()
             });
 
         let mut handler = GetPagedBooksHandler::new(Arc::new(repository));
         let result = handler.handle(GetPagedBooksQuery { page: 0, page_size: 3 }).await.unwrap();
 
-        assert_eq!(result.unwrap().len(), 3);
+        assert_eq!(result.clone().unwrap().len(), 3);
+        zip(result.unwrap().iter(), get_list_of_raw_isbns().iter()).for_each(|(book, isbn)| {
+            assert_eq!(book.isbn.to_string(), isbn.to_string());
+        });
+    }
+
+    #[tokio::test]
+    async fn when_invoking_a_get_paged_books_request_upon_a_list_of_enough_valid_books_to_complete_the_requested_batch_size_then_the_proper_slice_of_books_is_returned() {
+        let mut repository = MockBookRepository::new();
+        repository
+            .expect_get_all()
+            .times(1)
+            .returning(|| {
+                get_list_of_raw_books()
+            });
+
+        let mut handler = GetPagedBooksHandler::new(Arc::new(repository));
+        let result = handler.handle(GetPagedBooksQuery { page: 1, page_size: 1 }).await.unwrap();
+
+        assert_eq!(result.clone().unwrap().len(), 1);
+        assert_eq!(
+            result.unwrap().first().unwrap().isbn.to_string(),
+            get_list_of_raw_isbns().get(1).unwrap().to_string()
+        );
     }
 }

--- a/Services/book_catalog_service/src/domain/core/i_repository.rs
+++ b/Services/book_catalog_service/src/domain/core/i_repository.rs
@@ -11,5 +11,5 @@ pub trait IRepository<TEntity: Entity>: Send + Sync {
     /// The actual list of entities is wrapped in an ```Option``` to allow for the possibility of an empty list.
     ///
     /// Also, every item in the list is a ```Result``` to allow for the possibility of an invalid entity.
-    async fn get_paged(&self, page: u32, page_size: u32) -> Result<Option<Vec<Result<TEntity, Self::Error>>>, Self::Error>;
+    async fn get_all(&self) -> Result<Option<Vec<Result<TEntity, Self::Error>>>, Self::Error>;
 }


### PR DESCRIPTION
**Current behavior:** When a batch of books with a specified size is requested, only valid books are retrieved and hence the batch's dimension can vary

**Expected behavior:** Persist the size of the books batch even when invalid items are encountered

**Suggestions:** Perform the pagination logic inside the business logic layer and request only the complete list of books from the Infrastructure layer in order to loose its responsibility